### PR TITLE
fix: parameter conflict

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -304,11 +304,11 @@ export class MediaWikiApi {
     return result
   }
 
-  async parseWikitext(wikitext: string, page?: string): Promise<string> {
+  async parseWikitext(page?: string, pageid?: string): Promise<string> {
     const { data } = await this.post({
       action: 'parse',
       page,
-      text: wikitext,
+      pageid,
     })
     return data.parse.text
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -304,10 +304,10 @@ export class MediaWikiApi {
     return result
   }
 
-  async parseWikitext(wikitext: string, page?: string): Promise<string> {
+  async parseWikitext(wikitext: string, title?: string): Promise<string> {
     const { data } = await this.post({
       action: 'parse',
-      page,
+      title,
       text: wikitext,
     })
     return data.parse.text

--- a/src/index.ts
+++ b/src/index.ts
@@ -304,11 +304,11 @@ export class MediaWikiApi {
     return result
   }
 
-  async parseWikitext(page?: string, pageid?: string): Promise<string> {
+  async parseWikitext(wikitext: string, page?: string): Promise<string> {
     const { data } = await this.post({
       action: 'parse',
       page,
-      pageid,
+      text: wikitext,
     })
     return data.parse.text
   }


### PR DESCRIPTION
不可以同时使用page, pageid, oldid, text，通常使用page或pageid。