### PR TITLE
chore: update package.json exports for newer nodejs resolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,10 +2,22 @@
   "name": "wiki-saikou",
   "version": "3.3.1",
   "description": "The library provides the out of box accessing to MediaWiki API in both browsers & Node.js, and the syntax is very similar to vanilla `new mw.Api()`. TypeScript definition included~",
+  "type": "commonjs",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",
   "browser": "./dist/index.umd.js",
   "module": "./dist/index.mjs",
+  "exports": {
+    ".": {
+      "types": {
+        "import": "./lib/index.d.ts",
+        "require": "./lib/index.d.ts"
+      },
+      "import": "./dist/index.mjs",
+      "require": "./lib/index.js",
+      "browser": "./dist/index.umd.js"
+    }
+  },
   "files": [
     "dist",
     "lib"


### PR DESCRIPTION
This PR adds the `exports` field in `package.json` which is required in recent nodejs version to resolve the correct variation of the build result.
In this PR I don't want to make a huge breaking change so I specify the `type` to `commonjs`. But a general approach to support hybrid (i.e. ESM + CJS + others) package is to set `type` as `module` and name the cjs output a `.cjs` extension.

By the way, it looks like the pnpm lockfile was created long long ago, in my local, pnpm was trying to re-generate the whole file, so I didn't upload the lock file onto this PR. If it is required, you might need to update it on your side before this PR.