### PR TITLE
feat: 修复错误的Headers

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -64,9 +64,15 @@ export class MediaWikiApi {
     if (!('document' in globalThis)) {
       instance.interceptors.request.use((ctx) => {
         ctx.headers = (ctx.headers as Record<string, string>) || {}
-        ctx.headers['cookie'] = Array.from(this.cookies.entries())
+        const validCookies = Array
+          .from(this.cookies.entries())
+          .filter(([name]) => name
+            && !name.match(/[0-9]{2} [A-Za-z]{3} [0-9]{4}/) // Exclude cookies looked like expiration date
+            && name !== '')
           .map(([name, value]) => `${name}=${value}`)
-          .join('; ')
+        if (validCookies.length > 0) {
+          ctx.headers['cookie'] = validCookies.join('; ')
+        }
         return ctx
       })
       instance.interceptors.response.use((ctx) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -64,11 +64,8 @@ export class MediaWikiApi {
     if (!('document' in globalThis)) {
       instance.interceptors.request.use((ctx) => {
         ctx.headers = (ctx.headers as Record<string, string>) || {}
-        const validCookies = Array
-          .from(this.cookies.entries())
-          .filter(([name]) => name
-            && !name.match(/[0-9]{2} [A-Za-z]{3} [0-9]{4}/) // Exclude cookies looked like expiration date
-            && name !== '')
+        const validCookies = Array.from(this.cookies.entries())
+          .filter(([_, value]) => value && value.trim() !== '')
           .map(([name, value]) => `${name}=${value}`)
         if (validCookies.length > 0) {
           ctx.headers['cookie'] = validCookies.join('; ')


### PR DESCRIPTION
## Sourcery 总结

在 MediaWikiApi 请求拦截器中，设置 Cookie 请求头之前过滤并验证 cookies，排除无效名称并防止出现空的请求头。

Bug 修复：
- 在构建 cookie 请求头之前，过滤掉名称类似于过期日期或空字符串的 cookies
- 如果没有有效的 cookies，则跳过设置 cookie 请求头

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Filter and validate cookies before setting the Cookie header in the MediaWikiApi request interceptor, excluding invalid names and preventing empty headers.

Bug Fixes:
- Filter out cookies with names resembling expiration dates or empty strings before constructing the cookie header
- Skip setting the cookie header if there are no valid cookies

</details>